### PR TITLE
Improve canvas: scale and ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Should be a number between `0` (muted) or `1` (max volume).
 
 This callback is called every time that an FPS is reported.
 
+### `scale={number | undefined}`
+
+Set the emulator scale. Default value is `1`, which has width 240px and height 160px.
+
 # Contribution
 
 1 - Clone this repository

--- a/sample/src/components/emulator.tsx
+++ b/sample/src/components/emulator.tsx
@@ -1,8 +1,8 @@
 import React, { FunctionComponent } from 'react'
 import GBAEmulator from 'react-gbajs'
 
-type Props = { printFps: boolean }
-const Emulator: FunctionComponent<Props> = ({ printFps }) => {
+type Props = { scale: number, printFps: boolean }
+const Emulator: FunctionComponent<Props> = ({ scale, printFps }) => {
   const fpsReportCallback = (
     printFps
       ? (fps: number) => console.log('FPS', fps)
@@ -12,6 +12,7 @@ const Emulator: FunctionComponent<Props> = ({ printFps }) => {
   return (
     <GBAEmulator
       onFpsReported={fpsReportCallback}
+      scale={scale}
       volume={0}
     />
   )

--- a/sample/src/components/input-scale.tsx
+++ b/sample/src/components/input-scale.tsx
@@ -1,0 +1,18 @@
+import React, { FunctionComponent } from 'react'
+
+type Props = { scale: number, setScale: (value: number) => void }
+const InputScale: FunctionComponent<Props> = ({ scale, setScale }) => (
+  <div>
+    <label>Scale</label>
+    <input
+      type='range'
+      value={scale}
+      min={0.5}
+      step={0.25}
+      max={3}
+      onChange={(e) => { setScale(Number(e.target.value)) }}
+    />
+  </div>
+)
+
+export default InputScale

--- a/sample/src/pages/main.tsx
+++ b/sample/src/pages/main.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react'
 import Emulator from "../components/emulator"
 import InputROM from '../components/input-rom'
+import InputScale from '../components/input-scale'
 import Instructions from '../components/instructions'
 import TogglePrintFps from '../components/toggle-print-fps'
 
 const Main = () => {
   const [printFps, setPrintFps] = useState(false)
+  const [scale, setScale] = useState(1)
 
   return (
     <div
@@ -16,7 +18,8 @@ const Main = () => {
       <InputROM />
       <Instructions />
       <TogglePrintFps printFps={printFps} setPrintFps={setPrintFps} />
-      <Emulator printFps={printFps} />
+      <InputScale scale={scale} setScale={setScale} />
+      <Emulator scale={scale} printFps={printFps} />
     </div>
   )
 }

--- a/src/emulator/gba.js
+++ b/src/emulator/gba.js
@@ -86,24 +86,6 @@ GameBoyAdvance.prototype.requestFrame = function(callback) {
 };
 
 GameBoyAdvance.prototype.setCanvas = function(canvas) {
-	var self = this;
-	if (canvas.offsetWidth != 240 || canvas.offsetHeight != 160) {
-		this.indirectCanvas = document.createElement("canvas");
-		this.indirectCanvas.setAttribute("height", "160");
-		this.indirectCanvas.setAttribute("width", "240");
-		this.targetCanvas = canvas;
-		this.setCanvasDirect(this.indirectCanvas);
-		var targetContext = canvas.getContext('2d');
-		this.video.drawCallback = function() {
-			targetContext.drawImage(self.indirectCanvas, 0, 0, canvas.offsetWidth, canvas.offsetHeight);
-		}
-	} else {
-		this.setCanvasDirect(canvas);
-		var self = this;
-	}
-};
-
-GameBoyAdvance.prototype.setCanvasDirect = function(canvas) {
 	this.context = canvas.getContext('2d');
 	this.video.setBacking(this.context);
 };

--- a/src/emulator/index.js
+++ b/src/emulator/index.js
@@ -155,19 +155,6 @@ const drawEmulator = (buffer) => {
     }
   }
 
-  document.addEventListener('webkitfullscreenchange', function() {
-    var canvas = document.getElementById('screen');
-    if (document.webkitIsFullScreen) {
-      canvas.setAttribute('height', document.body.offsetHeight);
-      canvas.setAttribute('width', document.body.offsetHeight / 2 * 3);
-      canvas.setAttribute('style', 'margin: 0');
-    } else {
-      canvas.setAttribute('height', 320);
-      canvas.setAttribute('width', 480);
-      canvas.removeAttribute('style');
-    }
-  }, false);
-
   run(buffer)
 
   return gba

--- a/src/emulator/index.js
+++ b/src/emulator/index.js
@@ -17,7 +17,7 @@ import './gpio'
 import './gba'
 import biosBin from '../../assets/bios.bin'
 
-const drawEmulator = (buffer) => {
+const drawEmulator = (buffer, canvas) => {
   var gba
   var runCommands = []
   var debug = null
@@ -44,7 +44,6 @@ const drawEmulator = (buffer) => {
     gba = null;
   }
 
-  var canvas = document.getElementById('screen');
   gba.setCanvas(canvas);
 
   gba.logLevel = gba.LOG_ERROR;

--- a/src/react/gba-provider.js
+++ b/src/react/gba-provider.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
 import cloneDeep from 'lodash.clonedeep'
 import drawEmulator from '../emulator'
@@ -6,6 +6,7 @@ import GbaContext from './gba-context'
 
 const GbaProvider = ({ children }) => {
   const [gba, setGba] = useState()
+  const canvasRef = useRef()
   const [fpsCallback, setFpsCallback] = useState()
   const [romBufferMemory, setRomBufferMemory] = useState()
   const [frozenAddresses, setFrozenAddresses] = useState({})
@@ -13,7 +14,7 @@ const GbaProvider = ({ children }) => {
   const play = (newRomBufferMemory) => {
     setRomBufferMemory(new Uint8Array([...newRomBufferMemory]))
 
-    const newGbaInstance = drawEmulator(newRomBufferMemory)
+    const newGbaInstance = drawEmulator(newRomBufferMemory, canvasRef.current)
     newGbaInstance.reportFPS = fpsCallback
     setGba(newGbaInstance)
   }
@@ -44,6 +45,7 @@ const GbaProvider = ({ children }) => {
   return (
     <GbaContext.Provider value={{
       gba,
+      canvasRef,
       setFpsCallback: (newFpsCallback) => {
         setFpsCallback(newFpsCallback)
 

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -7,7 +7,7 @@ const defaultWidth = 240
 const defaultHeight = 160
 
 const ReactGbaJs = ({ onFpsReported, scale = 1, volume }) => {
-  const { gba, setFpsCallback } = useContext(GbaContext)
+  const { gba, setFpsCallback, canvasRef } = useContext(GbaContext)
 
   useEffect(() => {
     setFpsCallback(onFpsReported)
@@ -29,7 +29,7 @@ const ReactGbaJs = ({ onFpsReported, scale = 1, volume }) => {
       }}
     >
       <canvas
-        id="screen"
+        ref={canvasRef}
         width={defaultWidth}
         height={defaultHeight}
         style={{

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -3,7 +3,10 @@ import PropTypes from 'prop-types'
 import emulatorSetVolume from '../emulator/setVolume'
 import GbaContext from './gba-context'
 
-const ReactGbaJs = ({ onFpsReported, volume }) => {
+const defaultWidth = 240
+const defaultHeight = 160
+
+const ReactGbaJs = ({ onFpsReported, scale = 1, volume }) => {
   const { gba, setFpsCallback } = useContext(GbaContext)
 
   useEffect(() => {
@@ -19,12 +22,28 @@ const ReactGbaJs = ({ onFpsReported, volume }) => {
   }, [gba, volume])
 
   return (
-    <canvas id="screen" width="480" height="320" />
+    <div
+      style={{
+        width: defaultWidth * scale,
+        height: defaultHeight * scale,
+      }}
+    >
+      <canvas
+        id="screen"
+        width={defaultWidth}
+        height={defaultHeight}
+        style={{
+          transform: `scale(${scale})`,
+          transformOrigin: 'left top',
+        }}
+      />
+    </div>
   )
 }
 
 ReactGbaJs.propTypes = {
   onFpsReported: PropTypes.func,
+  scale: PropTypes.number,
   volume: PropTypes.number.isRequired,
 }
 


### PR DESCRIPTION
Two improvements on the canvas:
- use css transform to change its scale, which is faster (suggested here https://github.com/city41/smaghetti/discussions/29#discussioncomment-776751)
- use ref instead of `id` to find the element, to avoid name conflict