### PR TITLE
fix: update `GBAProvider` prop types for React 18

### DIFF
--- a/src/react/gba-provider.tsx
+++ b/src/react/gba-provider.tsx
@@ -3,7 +3,7 @@ import cloneDeep from 'lodash.clonedeep'
 import drawEmulator from '../emulator'
 import GbaContext from './gba-context'
 
-const GbaProvider: FunctionComponent = ({ children }) => {
+const GbaProvider: FunctionComponent<{children:ReactNode}> = ({ children }) => {
   const [gba, setGba] = useState<Gba>()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [fpsCallback, setFpsCallback] = useState<FpsCallback>()

--- a/src/react/gba-provider.tsx
+++ b/src/react/gba-provider.tsx
@@ -1,9 +1,13 @@
-import React, { FunctionComponent, useState, useRef } from 'react'
+import React, { FunctionComponent, useState, useRef, ReactNode } from 'react'
 import cloneDeep from 'lodash.clonedeep'
 import drawEmulator from '../emulator'
 import GbaContext from './gba-context'
 
-const GbaProvider: FunctionComponent<{children:ReactNode}> = ({ children }) => {
+type Props = {
+  children?: ReactNode
+};
+
+const GbaProvider: FunctionComponent<Props> = ({ children }) => {
   const [gba, setGba] = useState<Gba>()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const [fpsCallback, setFpsCallback] = useState<FpsCallback>()


### PR DESCRIPTION
Fixes #22 